### PR TITLE
rm send_msg_check

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -13,22 +13,18 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use cita_cloud_proto::client::{InterceptedSvc, NetworkMsgHandlerServiceClientTrait};
 use cita_cloud_proto::network::{
     network_msg_handler_service_client::NetworkMsgHandlerServiceClient, NetworkMsg,
 };
 use cita_cloud_proto::retry::RetryClient;
-use cloud_util::unix_now;
 use flume::Receiver;
-use parking_lot::RwLock;
 
 pub struct NetworkMsgDispatcher {
     pub inbound_msg_rx: Receiver<NetworkMsg>,
     pub dispatch_table:
         HashMap<String, RetryClient<NetworkMsgHandlerServiceClient<InterceptedSvc>>>,
-    pub send_msg_check: Arc<RwLock<u64>>,
 }
 
 impl NetworkMsgDispatcher {
@@ -46,20 +42,6 @@ impl NetworkMsgDispatcher {
                         );
                     }
                 });
-            } else if msg.module == "HEALTH_CHECK" {
-                let now = unix_now();
-                *self.send_msg_check.write() = now;
-                if let Ok(check_msg) = std::str::from_utf8(&msg.msg) {
-                    if let Some((time, _domain)) = check_msg.split_once('@') {
-                        if let Ok(time) = time.parse::<u64>() {
-                            info!(
-                                "Recycle the HEALTH_CHECK msg from: {:?}, by {}ms",
-                                &msg.origin,
-                                now - time
-                            );
-                        }
-                    }
-                }
             } else {
                 warn!(
                     "Unknown module, will drop msg: msg.module {} msg.origin {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ use cita_cloud_proto::{
 use clap::Parser;
 use cloud_util::metrics::{run_metrics_exporter, MiddlewareLayer};
 use cloud_util::panic_hook::set_panic_handler;
-use cloud_util::unix_now;
 use flume::unbounded;
 use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
@@ -118,13 +117,9 @@ async fn run(opts: RunOpts) {
         dispatch_table.insert(module.module_name.clone(), client);
     }
 
-    let send_msg_check = Arc::new(RwLock::new(unix_now()));
-    let send_msg_check_ = send_msg_check.clone();
-
     let dispatcher = NetworkMsgDispatcher {
         dispatch_table: dispatch_table.clone(),
         inbound_msg_rx,
-        send_msg_check: send_msg_check_,
     };
     tokio::spawn(async move {
         dispatcher.run().await;
@@ -176,7 +171,6 @@ async fn run(opts: RunOpts) {
                 )
                 .add_service(HealthServer::new(HealthCheckServer::new(
                     peers_for_health_check,
-                    send_msg_check,
                     config.health_check_timeout,
                 )))
                 .serve(grpc_addr)
@@ -192,7 +186,6 @@ async fn run(opts: RunOpts) {
                 )
                 .add_service(HealthServer::new(HealthCheckServer::new(
                     peers_for_health_check,
-                    send_msg_check,
                     config.health_check_timeout,
                 )))
                 .serve(grpc_addr)


### PR DESCRIPTION
业务层发送消息的检查不再需要，因为liveliness检查了domain与origin地址，可以认为也检查了业务层的发送消息逻辑